### PR TITLE
Install the latest stable kubectl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ SHELL ["/bin/bash", "-c"]
 RUN curl -sL https://sentry.io/get-cli/ | bash
 
 # install kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubectl \
+RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" \
     && mv ./kubectl /usr/local/bin/kubectl
 
 # add helper scripts


### PR DESCRIPTION
### Description

- Keep the `kubectl` version up to date.

Test this with :
```
$ docker run -it sourceboat/rancher-deploy kubectl version --client

Client Version: version.Info{Major:"1", Minor:"19", GitVersion:"v1.19.3", GitCommit:"1e11e4a2108024935ecfcb2912226cedeafd99df", GitTreeState:"clean", BuildDate:"2020-10-14T12:50:19Z", GoVersion:"go1.15.2", Compiler:"gc", Platform:"linux/amd64"}
```

Cheers.