### PR TITLE
fix repository and use newest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rancher/cli:v2.0.4
+FROM rancher/cli2:v2.6.4
 
 # install dependencies
 RUN apk update \


### PR DESCRIPTION
We are using an outdated tag from a deprecated repository.

- deprecated: https://hub.docker.com/r/rancher/cli/tags
- up to date: https://hub.docker.com/r/rancher/cli2/tags
